### PR TITLE
Add btcd simnet to valid network list

### DIFF
--- a/src/decoder.js
+++ b/src/decoder.js
@@ -158,7 +158,7 @@ function parsePrefix(prefix) {
 }
 
 function isValidNetwork(network) {
-  return network === 'bc' || network === 'tb' || network === 'crt';
+  return network === 'bc' || network === 'tb' || network === 'crt' || network === 'sb';
 }
 
 function isValidAmount(amount) {

--- a/src/decoder.spec.js
+++ b/src/decoder.spec.js
@@ -265,3 +265,11 @@ describe('test vectors', () => {
     expect(result.pubkey).toEqual(pubkey);
   });
 });
+
+test('send 0.02 BTC, on simnet', () => {
+  let input =
+    'lnsb20m1pd3dfr9pp5s90vpp5a7sxzd4zenxxesvfge73nqslj4h7zn29059hgyp7jdvjqdqqcqzysqngw58lu63trytwj7ktx7vasdutvvan7paq5qrgjj6wg065qzr8pv8p6q7kcdeg0kdpek09gc7xf6y972gy7t3pl6gtcqww440znz6gpfec4kj';
+  let result = decoder.decode(input);
+  expect(result.network).toBe('sb');
+  expect(result.amount).toBe(0.02);
+});


### PR DESCRIPTION
btcd has simnet mode, which is similar to regtest mode for bitcoind.
Also, lnd can be run in simnet mode.

Currently, decoding simnet invoice throws an invalid network error. 

```
> invoice.decode('lnsb1pd3d8fhpp5nc5kplnmxpdy243gm8svtt6k7j45x9vur6vd9xj7djn0gxqdgnrqdqqcqzyslrx06l6ep9ls3xdmqx8z5940dkuj9hgt0ksg8j6mh220m2l6pan5rsczr2hphl5cqgpr6tcr8htv2ytqch9lkawmp28xavq3de4pzxqqrrkanj')
Error: Invalid network
    at parsePrefix (/Users/zat/.ghq/github.com/uiureo/pika/client/node_modules/lightning-invoice/src/decoder.js:151:39)
    at Object.decode (/Users/zat/.ghq/github.com/uiureo/pika/client/node_modules/lightning-invoice/src/decoder.js:16:29)
```

Human readable part for simnet is not defined in [BIP 173](https://github.com/bitcoin/bips/blob/master/bip-0173.mediawiki#cite_ref-7-0),
but accepting it would be useful for development.

By the way, thanks for creating such a great module. This module saved me hours.
